### PR TITLE
[DataStorage]Replace getDeviceID functions in storage.go file with helper.go

### DIFF
--- a/internal/controller/storagemgr/storage.go
+++ b/internal/controller/storagemgr/storage.go
@@ -242,10 +242,3 @@ func saveYaml() (err error) {
 	return
 }
 
-func getDeviceID() (string, error) {
-	UUIDv4, err := ioutil.ReadFile(deviceIDFilePath)
-	if err != nil {
-		return "", err
-	}
-	return string(UUIDv4), nil
-}


### PR DESCRIPTION
Signed-off-by: Seughui98 <hithere1012@naver.com>

# Description

We have to replace getDeviceID in storage.go file with GetDevice function. 
So, I called GetDevice() in the helper.go file and changed it.

Fixes [#321](https://github.com/lf-edge/edge-home-orchestration-go/issues/321) (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Code cleanup/refactoring


# How Has This Been Tested?


**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker 20.10.6 and Go 1.16.3
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

